### PR TITLE
Add benchmark and improve tokenizer performance

### DIFF
--- a/e2e/commentmap_test.go
+++ b/e2e/commentmap_test.go
@@ -14,7 +14,7 @@ import (
 
 func parseFile(t *testing.T, src string) *sqlast.File {
 	t.Helper()
-	parser, err := xsqlparser.NewParser(strings.NewReader(src), &dialect.GenericSQLDialect{}, xsqlparser.ParseComment)
+	parser, err := xsqlparser.NewParser(strings.NewReader(src), &dialect.GenericSQLDialect{}, xsqlparser.ParseComment())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/example/main.go
+++ b/example/main.go
@@ -126,7 +126,7 @@ CREATE TABLE test (
 ); --associate with stmts2
 `
 
-	parser, err := xsqlparser.NewParser(bytes.NewBufferString(src), &dialect.GenericSQLDialect{}, xsqlparser.ParseComment)
+	parser, err := xsqlparser.NewParser(bytes.NewBufferString(src), &dialect.GenericSQLDialect{}, xsqlparser.ParseComment())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/parser.go
+++ b/parser.go
@@ -24,9 +24,11 @@ type Parser struct {
 
 type ParserOption func(*Parser)
 
-func ParseComment(p *Parser) {
-	p.parseComment = true
-	p.comments = make(map[sqltoken.Pos]*sqlast.CommentGroup)
+func ParseComment() ParserOption {
+	return func(p *Parser) {
+		p.parseComment = true
+		p.comments = make(map[sqltoken.Pos]*sqlast.CommentGroup)
+	}
 }
 
 func NewParser(src io.Reader, dialect dialect.Dialect, opts ...ParserOption) (*Parser, error) {
@@ -43,6 +45,20 @@ func NewParser(src io.Reader, dialect dialect.Dialect, opts ...ParserOption) (*P
 	}
 
 	return parser, nil
+}
+
+func NewParserWithOptions(opts ...ParserOption) *Parser {
+	parser := &Parser{index: 0}
+	for _, o := range opts {
+		o(parser)
+	}
+	return parser
+}
+
+// workaround
+// FIXME: create appropriate parse function
+func (p *Parser) SetTokens(tokens []*sqltoken.Token) {
+	p.tokens = tokens
 }
 
 func (p *Parser) ParseFile() (*sqlast.File, error) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -2091,7 +2091,7 @@ select 1 from test; /*lll*/ --mmm
 			if c.skip {
 				t.Skip()
 			}
-			parser, err := NewParser(bytes.NewBufferString(c.in), &dialect.GenericSQLDialect{}, ParseComment)
+			parser, err := NewParser(bytes.NewBufferString(c.in), &dialect.GenericSQLDialect{}, ParseComment())
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/sqltoken/tokenizer.go
+++ b/sqltoken/tokenizer.go
@@ -393,20 +393,21 @@ func (t *Tokenizer) next() (Kind, interface{}, error) {
 }
 
 func (t *Tokenizer) tokenizeWord(f rune) string {
-	var str []rune
-	str = append(str, f)
+	var builder strings.Builder
+	builder.WriteRune(f)
 
 	for {
 		r := t.Scanner.Peek()
 		if t.Dialect.IsIdentifierPart(r) {
 			t.Scanner.Next()
-			str = append(str, r)
+			builder.WriteRune(r)
 		} else {
 			break
 		}
 	}
+	str := builder.String()
 	t.Col += len(str)
-	return string(str)
+	return str
 }
 
 func (t *Tokenizer) tokenizeSingleQuotedString() (string, error) {

--- a/sqltoken/tokenizer.go
+++ b/sqltoken/tokenizer.go
@@ -437,13 +437,15 @@ func (t *Tokenizer) tokenizeWord(f rune) string {
 			break
 		}
 	}
+
 	str := builder.String()
 	t.Col += len(str)
 	return str
 }
 
 func (t *Tokenizer) tokenizeSingleQuotedString() (string, error) {
-	var str []rune
+	// var str []rune
+	var builder strings.Builder
 	t.Scanner.Next()
 
 	for {
@@ -451,7 +453,8 @@ func (t *Tokenizer) tokenizeSingleQuotedString() (string, error) {
 		if n == '\'' {
 			t.Scanner.Next()
 			if t.Scanner.Peek() == '\'' {
-				str = append(str, '\'')
+				// str = append(str, '\'')
+				builder.WriteRune('\'')
 				t.Scanner.Next()
 			} else {
 				break
@@ -459,15 +462,17 @@ func (t *Tokenizer) tokenizeSingleQuotedString() (string, error) {
 			continue
 		}
 		if n == scanner.EOF {
-			return "", errors.Errorf("unclosed single quoted string: %s at %+v", string(str), t.Pos())
+			return "", errors.Errorf("unclosed single quoted string: %s at %+v", builder.String(), t.Pos())
 		}
 
 		t.Scanner.Next()
-		str = append(str, n)
+		builder.WriteRune(n)
+		// str = append(str, n)
 	}
+	str := builder.String()
 	t.Col += 2 + len(str)
 
-	return string(str), nil
+	return str, nil
 }
 
 func (t *Tokenizer) tokenizeMultilineComment() (string, error) {

--- a/sqltoken/tokenizer_test.go
+++ b/sqltoken/tokenizer_test.go
@@ -660,6 +660,22 @@ GROUP BY country
 HAVING COUNT(customer_id) > 3`,
 		},
 		{
+			name: "complex select",
+			src: `SELECT start_terminal,
+       start_time,
+       duration_seconds,
+       ROW_NUMBER() OVER (ORDER BY start_time)
+                    AS row_number
+  FROM tutorial.dc_bikeshare_q1_2012
+ WHERE start_time < '2012-01-08'`,
+		},
+		{
+			name: "insert",
+			src:  `INSERT INTO tbl_name (a,b,c) VALUES(1,2,3),(4,5,6),(7,8,9);`,
+		},
+
+		{
+
 			name: "multi line comment",
 			src: `
 create table account (


### PR DESCRIPTION
goos: darwin
goarch: amd64
pkg: github.com/akito0107/xsqlparser/sqltoken

```name                                      old time/op    new time/op    delta
Tokenizer_Tokenize/select-12                6.62µs ± 1%    5.21µs ± 0%  -21.33%  (p=0.000 n=9+8)
Tokenizer_Tokenize/complex_select-12        12.2µs ± 0%    10.1µs ± 0%  -16.69%  (p=0.000 n=10+8)
Tokenizer_Tokenize/insert-12                5.49µs ± 0%    5.67µs ±18%     ~     (p=0.497 n=9+10)
Tokenizer_Tokenize/multi_line_comment-12    16.5µs ± 1%    15.4µs ± 6%   -7.06%  (p=0.000 n=10+10)

name                                      old alloc/op   new alloc/op   delta
Tokenizer_Tokenize/select-12                6.22kB ± 0%    5.43kB ± 0%  -12.72%  (p=0.000 n=10+10)
Tokenizer_Tokenize/complex_select-12        11.8kB ± 0%    10.4kB ± 0%  -12.31%  (p=0.000 n=10+10)
Tokenizer_Tokenize/insert-12                5.88kB ± 0%    5.66kB ± 0%   -3.67%  (p=0.000 n=10+10)
Tokenizer_Tokenize/multi_line_comment-12    13.6kB ± 0%    12.6kB ± 0%   -7.53%  (p=0.000 n=10+10)

name                                      old allocs/op  new allocs/op  delta
Tokenizer_Tokenize/select-12                   112 ± 0%        79 ± 0%  -29.46%  (p=0.000 n=10+10)
Tokenizer_Tokenize/complex_select-12           195 ± 0%       150 ± 0%  -23.08%  (p=0.000 n=10+10)
Tokenizer_Tokenize/insert-12                   109 ± 0%        95 ± 0%  -12.84%  (p=0.000 n=10+10)
Tokenizer_Tokenize/multi_line_comment-12       302 ± 0%       246 ± 0%  -18.54%  (p=0.000 n=10+10)```