### PR TITLE
Add a case for a NamedColumnsJoin in the walker

### DIFF
--- a/sqlast/walk.go
+++ b/sqlast/walk.go
@@ -157,6 +157,8 @@ func Walk(v Visitor, node Node) {
 		Walk(v, n.Ref)
 	case *JoinType:
 	// nothing to do
+	case *NamedColumnsJoin:
+	// nothing to do
 	case *JoinCondition:
 		Walk(v, n.SearchCondition)
 	case *NaturalJoin:


### PR DESCRIPTION
Hi!

While trying to use a join with a using clause, I was getting a panic as it said that the type `sqlast.NamedColumnsJoin` was not implemented.

I've added a case for that type, with no more code to do, as it should work as a regular `JoinType`.

I've tested this code and it seems to work correctly, as it returns a list of `TableReference`.

Example input:
```sql
select * from foobar join barfoo USING (xyzzy,foo,orange)
```

Output:
```
&sqlast.QueryStmt{
  stmt: sqlast.stmt{},
  With: sqltoken.Pos{
    Line: 0,
    Col:  0,
  },
  CTEs: []*sqlast.CTE{},
  Body: &sqlast.SQLSelect{
    sqlSetExpr: sqlast.sqlSetExpr{},
    Distinct:   false,
    Projection: []sqlast.SQLSelectItem{
      &sqlast.UnnamedSelectItem{
        sqlSelectItem: sqlast.sqlSelectItem{},
        Node:          &sqlast.Wildcard{
          Wildcard: sqltoken.Pos{
            Line: 1,
            Col:  8,
          },
        },
      },
    },
    FromClause: []sqlast.TableReference{
      &sqlast.QualifiedJoin{
        tableReference: sqlast.tableReference{},
        LeftElement:    &sqlast.TableJoinElement{
          joinElement: sqlast.joinElement{},
          Ref:         &sqlast.Table{
            tableFactor:    sqlast.tableFactor{},
            tableReference: sqlast.tableReference{},
            Name:           &sqlast.ObjectName{
              Idents: []*sqlast.Ident{
                &sqlast.Ident{
                  Value: "foobar",
                  From:  sqltoken.Pos{
                    Line: 1,
                    Col:  15,
                  },
                  To: sqltoken.Pos{
                    Line: 1,
                    Col:  21,
                  },
                },
              },
            },
            Alias:      (*sqlast.Ident)(nil),
            Args:       []sqlast.Node{},
            ArgsRParen: sqltoken.Pos{
              Line: 0,
              Col:  0,
            },
            WithHints:       []sqlast.Node{},
            WithHintsRParen: sqltoken.Pos{
              Line: 0,
              Col:  0,
            },
          },
        },
        Type: &sqlast.JoinType{
          Condition: 7,
          From:      sqltoken.Pos{
            Line: 0,
            Col:  0,
          },
          To: sqltoken.Pos{
            Line: 0,
            Col:  0,
          },
        },
        RightElement: &sqlast.TableJoinElement{
          joinElement: sqlast.joinElement{},
          Ref:         &sqlast.Table{
            tableFactor:    sqlast.tableFactor{},
            tableReference: sqlast.tableReference{},
            Name:           &sqlast.ObjectName{
              Idents: []*sqlast.Ident{
                &sqlast.Ident{
                  Value: "barfoo",
                  From:  sqltoken.Pos{
                    Line: 1,
                    Col:  27,
                  },
                  To: sqltoken.Pos{
                    Line: 1,
                    Col:  33,
                  },
                },
              },
            },
            Alias:      (*sqlast.Ident)(nil),
            Args:       []sqlast.Node{},
            ArgsRParen: sqltoken.Pos{
              Line: 0,
              Col:  0,
            },
            WithHints:       []sqlast.Node{},
            WithHintsRParen: sqltoken.Pos{
              Line: 0,
              Col:  0,
            },
          },
        },
        Spec: &sqlast.NamedColumnsJoin{
          joinSpec:   sqlast.joinSpec{},
          ColumnList: []*sqlast.Ident{
            &sqlast.Ident{
              Value: "xyzzy",
              From:  sqltoken.Pos{
                Line: 1,
                Col:  41,
              },
              To: sqltoken.Pos{
                Line: 1,
                Col:  46,
              },
            },
            &sqlast.Ident{
              Value: "foo",
              From:  sqltoken.Pos{
                Line: 1,
                Col:  47,
              },
              To: sqltoken.Pos{
                Line: 1,
                Col:  50,
              },
            },
            &sqlast.Ident{
              Value: "orange",
              From:  sqltoken.Pos{
                Line: 1,
                Col:  51,
              },
              To: sqltoken.Pos{
                Line: 1,
                Col:  57,
              },
            },
          },
          Using: sqltoken.Pos{
            Line: 0,
            Col:  0,
          },
          RParen: sqltoken.Pos{
            Line: 0,
            Col:  0,
          },
        },
      },
    },
    WhereClause:   nil,
    GroupByClause: []sqlast.Node{},
    HavingClause:  nil,
    Select:        sqltoken.Pos{
      Line: 1,
      Col:  1,
    },
  },
  OrderBy: []*sqlast.OrderByExpr{},
  Limit:   (*sqlast.LimitExpr)(nil),
}
```